### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-#JavaScript Scope Context Coloring
+# JavaScript Scope Context Coloring
 
 A JavaScript experiment in switching between syntax highlighting and scope colorizing, built on JSLint and CodeMirror and inspired by Douglas Crockford.
 
-##[Check out the Live Examples](http://daniellmb.github.io/JavaScript-Scope-Context-Coloring/example/scope-coloring.html#fullmonad)
+## [Check out the Live Examples](http://daniellmb.github.io/JavaScript-Scope-Context-Coloring/example/scope-coloring.html#fullmonad)
 
 It's [not perfect yet](http://daniellmb.github.io/JavaScript-Scope-Context-Coloring/test/), pull requests welcome! :)
 
-###Switch between Syntax Highlighting and Scope Context Coloring
+### Switch between Syntax Highlighting and Scope Context Coloring
 [![JavaScript Scope Context Coloring Switching](http://daniellmb.github.io/JavaScript-Scope-Context-Coloring/example/color-switching.gif "JavaScript Scope Context Coloring Switching")](http://daniellmb.github.io/JavaScript-Scope-Context-Coloring/example/scope-coloring.html#fullmonad)
 
-###Real-time Scope Context Coloring
+### Real-time Scope Context Coloring
 [![JavaScript Scope Context Coloring](http://daniellmb.github.io/JavaScript-Scope-Context-Coloring/example/realtime-color.gif "Real-time JavaScript Scope Context Coloring")](http://daniellmb.github.io/JavaScript-Scope-Context-Coloring/example/scope-coloring.html#level10)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
